### PR TITLE
Add TBB/OpenCV Mandelbrot viewer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.14)
+project(MandelbrotViewer CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+find_package(TBB REQUIRED)
+find_package(OpenCV REQUIRED)
+
+add_executable(mandelbrot main.cpp)
+target_link_libraries(mandelbrot PRIVATE TBB::tbb ${OpenCV_LIBS})

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Mandelbrot
+# Mandelbrot Viewer
+
+This project renders and visualizes the Mandelbrot set using Intel TBB for parallel tile-based rendering and OpenCV for displaying the image.
+
+## Building
+
+Dependencies:
+- Intel TBB
+- OpenCV
+- A C++17 compiler and CMake 3.14+
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+Run the application with `./mandelbrot`.
+
+Use the keyboard to move around (`W`, `A`, `S`, `D`) and zoom with `+`/`-`. Press `q` or `Esc` to exit.

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,80 @@
+#include <opencv2/opencv.hpp>
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+#include <mutex>
+#include <complex>
+#include <vector>
+
+int main() {
+    const int width = 800;
+    const int height = 600;
+    const int maxIter = 500;
+    cv::Mat image(height, width, CV_8UC3);
+
+    double centerX = -0.7;
+    double centerY = 0.0;
+    double scale = 3.0;
+    const double zoomFactor = 0.8;
+
+    cv::namedWindow("Mandelbrot", cv::WINDOW_AUTOSIZE);
+    std::mutex mtx;
+
+    auto render = [&]() {
+        const int tileSize = 64;
+        std::vector<cv::Rect> tiles;
+        for (int y = 0; y < height; y += tileSize) {
+            for (int x = 0; x < width; x += tileSize) {
+                tiles.emplace_back(x, y,
+                    std::min(tileSize, width - x),
+                    std::min(tileSize, height - y));
+            }
+        }
+
+        tbb::parallel_for(size_t(0), tiles.size(), [&](size_t i) {
+            cv::Rect roi = tiles[i];
+            for (int r = roi.y; r < roi.y + roi.height; ++r) {
+                for (int c = roi.x; c < roi.x + roi.width; ++c) {
+                    double zx = centerX + (c - width / 2.0) * scale / width;
+                    double zy = centerY + (r - height / 2.0) * scale / width;
+                    std::complex<double> z(0, 0);
+                    std::complex<double> cplx(zx, zy);
+                    int iter = 0;
+                    while (iter < maxIter && std::abs(z) <= 2.0) {
+                        z = z * z + cplx;
+                        ++iter;
+                    }
+                    int color = static_cast<int>(255.0 * iter / maxIter);
+                    image.at<cv::Vec3b>(r, c) =
+                        iter == maxIter ? cv::Vec3b(0, 0, 0)
+                                         : cv::Vec3b(0, color, 255 - color);
+                }
+            }
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                cv::imshow("Mandelbrot", image);
+                cv::waitKey(1);
+            }
+        });
+    };
+
+    render();
+    while (true) {
+        int key = cv::waitKey(0);
+        if (key == 27 || key == 'q')
+            break;
+        if (key == 'w')
+            centerY -= scale * 0.1;
+        if (key == 's')
+            centerY += scale * 0.1;
+        if (key == 'a')
+            centerX -= scale * 0.1;
+        if (key == 'd')
+            centerX += scale * 0.1;
+        if (key == '+')
+            scale *= zoomFactor;
+        if (key == '-')
+            scale /= zoomFactor;
+        render();
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add tile-based Mandelbrot renderer using TBB and OpenCV
- document build instructions
- create CMake build system

## Testing
- `cmake ..` *(fails: Could not find TBB)*
- `g++ -std=c++17 ../main.cpp -o mandelbrot -ltbb -lopencv_core -lopencv_highgui -lopencv_imgproc` *(fails: opencv2/opencv.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a7afc6644832a8bf4df2526589b63